### PR TITLE
Add notebook for taking stratified sample

### DIFF
--- a/stratified_sampler.ipynb
+++ b/stratified_sampler.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b687a165-976e-46cf-88e6-aff6708ed17e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import pathlib\n",
+    "SEED = 19221991 #Initially random, yet replicable\n",
+    "SAMPLE_SIZE = int(100 / 4) # 100 total registrars to check\n",
+    "# Bikeshedding way to write to user directory\n",
+    "USER_DIR = str(pathlib.Path.home()) + '/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43fa2a29-ad6b-445e-a56d-629a4eeaa07d",
+   "metadata": {},
+   "source": [
+    "It's too much work to check the payment methods for every single registrar represented in our set, so instead we'll take a stratified sample.\n",
+    "The set is already sorted by malicious_ratio descending. We'll make every quartile a stratum and then sample from that.\n",
+    "\n",
+    "To make it easier to manually find these registrars' sites, we merge the ICANN list of currently accredited registrars, because the contact info includes a website. Otherwise, it's really hard to map legal names to brand names for many registrars, and even harder the other way around.\n",
+    "\n",
+    "Not all of them are mapped, I believe the only ones missing are for deactivated registrars? Unconfirmed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b3381b0-6368-4b1e-901a-1f3381e1782e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"/data/most_malicious.csv\")\n",
+    "registrars = pd.read_csv(\"/data/Accredited-Registrars-202412054424.csv\")\n",
+    "\n",
+    "size_before = len(df)\n",
+    "df = df.rename(columns={\"registrar_id\":\"IANA Number\"})\n",
+    "df = df.merge(registrars,on=\"IANA Number\",how=\"left\")\n",
+    "df.drop('Registrar Name', axis=1, inplace=True) # Redundant\n",
+    "assert(size_before == len(df)) # We shouldn't lose/gain any entries when merging\n",
+    "# Slots for manual info gathering we need\n",
+    "df['Supports Crypto'] = None\n",
+    "df['Free Services'] = None\n",
+    "#df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36b49df2-3022-422b-bed4-8fa7b85ec1d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strata = np.array_split(df,4) #List of 4 dataframes, probably not equally sized\n",
+    "print([len(stratum) for stratum in strata])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6824bd87-9841-4f34-8874-4702c6aa9772",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples = list()\n",
+    "for stratum in strata:\n",
+    "    samples.append(stratum.sample(n=SAMPLE_SIZE,random_state=SEED))\n",
+    "#samples[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5af505b7-0971-4bbf-9478-6545af2a8f87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, sample in enumerate(samples):\n",
+    "    sample.to_csv(USER_DIR + 'stratum_'+str(i)+'_sample.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
We need to collect service/payment data manually, and 300+ registrars is too much. We'll take a sample of 100 from each quartile.

This notebook generates the sample CSVs, which we then need to manually fill in with the data.